### PR TITLE
Set action from header in writeDatasetHeader

### DIFF
--- a/SdmxDataParser/src/main/java/org/sdmxsource/sdmx/dataparser/engine/writer/streaming/StreamDataWriterEngineBase.java
+++ b/SdmxDataParser/src/main/java/org/sdmxsource/sdmx/dataparser/engine/writer/streaming/StreamDataWriterEngineBase.java
@@ -40,6 +40,7 @@ import org.sdmxsource.sdmx.api.model.beans.registry.ProvisionAgreementBean;
 import org.sdmxsource.sdmx.api.model.header.DatasetHeaderBean;
 import org.sdmxsource.sdmx.api.model.header.HeaderBean;
 import org.sdmxsource.sdmx.api.model.header.PartyBean;
+import org.sdmxsource.sdmx.sdmxbeans.model.header.DatasetHeaderBeanImpl;
 import org.sdmxsource.sdmx.util.beans.ConceptRefUtil;
 import org.sdmxsource.sdmx.util.date.DateUtil;
 import org.sdmxsource.util.ObjectUtil;
@@ -339,7 +340,7 @@ public abstract class StreamDataWriterEngineBase implements DataWriterEngine {
 
             closeDataset();
 
-            writeDatasetHeader(dataSetInfo);
+            writeDatasetHeader(dataSetInfo, header.getAction());
             currentPosition = POSITION.DATASET;
 
         } catch (Throwable e) {
@@ -656,9 +657,10 @@ public abstract class StreamDataWriterEngineBase implements DataWriterEngine {
      * Writes out the dataset header to the writer
      *
      * @param dataSetInfo contains base information about dataset
+     * @param datasetAction contains action performed on dataset
      * @throws XMLStreamException the xml stream exception
      */
-    protected void writeDatasetHeader(DataSetInfo dataSetInfo) throws XMLStreamException {
+    protected void writeDatasetHeader(DataSetInfo dataSetInfo, DATASET_ACTION datasetAction) throws XMLStreamException {
 
         Namespace datasetNamespace = this.dataSetInfo.datasetNamespace;
         if (!isTwoPointOne() && dataFormat == BASE_DATA_FORMAT.GENERIC) {
@@ -685,6 +687,8 @@ public abstract class StreamDataWriterEngineBase implements DataWriterEngine {
         }
         if (dataSetInfo.headerBean != null) {
             DatasetHeaderBean datasetHeader = dataSetInfo.headerBean;
+            ((DatasetHeaderBeanImpl) datasetHeader).setAction(datasetAction);
+
             if (ObjectUtil.validString(datasetHeader.getPublicationPeriod())) {
                 writer.writeAttribute("publicationPeriod", datasetHeader.getPublicationPeriod());
             }


### PR DESCRIPTION
There is a case when we need to call startDataset() multiple times on writer before closing. In current implementation, 'action' parameter in DataSet header always stays the same as it was during the first startDataset() call, since dataSetInfo is initialized only once. This PR fixes the issue by setting actual action value to headerBean's action field.